### PR TITLE
Remove google plus link

### DIFF
--- a/src/ui/components/main-footer/template.hbs
+++ b/src/ui/components/main-footer/template.hbs
@@ -24,9 +24,6 @@
         <a href="https://github.com/emberjs/ember.js" title="GitHub">
           <i class="icon-github"></i>
         </a>
-        <a href="https://plus.google.com/communities/106387049790387471205" title="Google+">
-          <i class="icon-gplus"></i>
-        </a>
       </div>
     </div>
 


### PR DESCRIPTION
This PR removes the Google plus link from the footer. That page isn't active and has a bit of spam.

It looks like the glimmer-styleguide is used in the emberjs/website app referenced here: https://github.com/emberjs/website/blob/master/source/layout.erb#L74